### PR TITLE
add default child_spec/1

### DIFF
--- a/lib/gen_state_machine.ex
+++ b/lib/gen_state_machine.ex
@@ -484,6 +484,20 @@ defmodule GenStateMachine do
     quote location: :keep do
       @behaviour GenStateMachine
 
+      @args unquote(args)
+
+      @doc false
+      def child_spec(arg) do
+        default = %{
+          id: __MODULE__,
+          start: {__MODULE__, :start_link, [arg]}
+        }
+
+        Supervisor.child_spec(default, @args)
+      end
+
+      defoverridable child_spec: 1
+
       unless unquote(@gen_statem_callback_mode_callback) do
         @before_compile GenStateMachine
       end

--- a/test/gen_state_machine_test.exs
+++ b/test/gen_state_machine_test.exs
@@ -149,4 +149,26 @@ defmodule GenStateMachineTest do
       assert Thrower.code_change(nil, nil, nil, nil) == {:handle_event_function, nil, nil}
     end
   end
+
+  test "generates child_spec/1" do
+    assert EventFunctionSwitch.child_spec([:hello]) == %{
+             id: EventFunctionSwitch,
+             start: {EventFunctionSwitch, :start_link, [[:hello]]}
+           }
+
+    defmodule CustomEventFunctionSwitch do
+      use GenStateMachine, id: :id, restart: :temporary, shutdown: :infinity, start: {:foo, :bar, []}
+
+      def init(args) do
+        {:ok, args}
+      end
+    end
+
+    assert CustomEventFunctionSwitch.child_spec([:hello]) == %{
+             id: :id,
+             restart: :temporary,
+             shutdown: :infinity,
+             start: {:foo, :bar, []}
+           }
+  end
 end


### PR DESCRIPTION
Hi! great library, thanks for providing the wrapper. I'm using it in a project and am learning a lot about `genstatem`.

Was defining the `child_spec/1` callbacks and noticed that `GenServer` has them included by default, so I ported over GenServer's implementation in master to here. Any interest?

Thanks!

