### PR TITLE
Remove name from options to satisfy dialyzer.

### DIFF
--- a/lib/gen_state_machine.ex
+++ b/lib/gen_state_machine.ex
@@ -618,7 +618,7 @@ defmodule GenStateMachine do
   """
   @spec start_link(module, any, GenServer.options) :: GenServer.on_start
   def start_link(module, args, options \\ []) do
-    name = options[:name]
+    {name, options} = Keyword.pop(options, :name)
 
     if name do
       name =
@@ -642,7 +642,7 @@ defmodule GenStateMachine do
   """
   @spec start(module, any, GenServer.options) :: GenServer.on_start
   def start(module, args, options \\ []) do
-    name = options[:name]
+    {name, options} = Keyword.pop(options, :name)
 
     if name do
       name =


### PR DESCRIPTION
This change pops the `:name` key out of the options list. If we don't do this then dialyzer says theres no local return because we're passing the name option to `gen_statem.start_link` and `:name` isn't a valid option for that function.

Error:

```
Function start_link/2 has no local return
The call 'Elixir.GenStateMachine':start_link('Elixir.MyApp.Server',{'foo',_,_},[{'name',_},...]) will never return since it differs in the 3rd argument from the success typing arguments: (atom(),any(),[{'debug',['debug' | 'log' | 'statistics' | 'trace' | {_,_}]} | {'spawn_opt',['link' | 'monitor' | {_,_}]} | {'timeout','infinity' | non_neg_integer()}])
```

I tested this by using my local fork with my app, rebuilt the plt from scratch, and confirmed that it solves the problem.