### PR TITLE
Adds GenStateMachine.child_spec/1

### DIFF
--- a/lib/gen_state_machine.ex
+++ b/lib/gen_state_machine.ex
@@ -518,7 +518,17 @@ defmodule GenStateMachine do
         :undefined
       end
 
-      overridable_funcs = [init: 1, terminate: 3, code_change: 4]
+      @doc false
+      def child_spec(arg) do
+        default = %{
+          id: __MODULE__,
+          start: {__MODULE__, :start_link, [arg]}
+        }
+
+        Supervisor.child_spec(default, unquote(args))
+      end
+
+      overridable_funcs = [init: 1, terminate: 3, code_change: 4, child_spec: 1]
 
       overridable_funcs =
         if @gen_statem_callback_mode == :handle_event_function do

--- a/test/gen_state_machine_test.exs
+++ b/test/gen_state_machine_test.exs
@@ -86,6 +86,24 @@ defmodule GenStateMachineTest do
     assert GenStateMachine.stop(:stack, :normal) == :ok
   end
 
+  test "child_spec/1" do
+    assert EventFunctionSwitch.child_spec([:hello]) == %{
+             id: EventFunctionSwitch,
+             start: {EventFunctionSwitch, :start_link, [[:hello]]}
+           }
+
+    defmodule CustomStack do
+      use GenStateMachine, id: :id, restart: :temporary, shutdown: :infinity, start: {:foo, :bar, []}
+    end
+
+    assert CustomStack.child_spec([:hello]) == %{
+             id: :id,
+             restart: :temporary,
+             shutdown: :infinity,
+             start: {:foo, :bar, []}
+           }
+  end
+
   defmodule BadInit1 do
     use GenStateMachine
 


### PR DESCRIPTION
This PR adds `child_spec/1` to `GenStateMachine`.

It allows `GenStateMachine` to be used with the newer child spec syntax used by `Supervisor` & `DynamicSupervisor`.

```elixir
defmodule Engine do
  use GenStateMachine

  def start_link(args) do
    GenStateMachine.start_link(__MODULE__, [], args)
  end

  def init(data) do
    {:ok, nil, data}
  end
end

Engine.child_spec([foo: 1]) #=> %{id: Engine, start: {Engine, :start_link, [[foo: 1]]}}

{:ok, sup} = DynamicSupervisor.start_link(strategy: :one_for_one)
DynamicSupervisor.start_child(sup, {Engine, []})
```

It also allows child spec options to be defined when `use`'ing the module. ie

```elixir
defmodule Engine do
  use GenStateMachine, restart: :permanent
end
```