### PR TITLE
Wrap reason spec in parentheses for code_change callback

### DIFF
--- a/lib/gen_state_machine.ex
+++ b/lib/gen_state_machine.ex
@@ -436,7 +436,7 @@ defmodule GenStateMachine do
   @callback code_change(old_vsn :: term | {:down, vsn :: term}, state, data, extra :: term) ::
               {:ok, state, data}
               | {callback_mode, state, data}
-              | reason :: term
+              | (reason :: term)
 
   @doc """
   Invoked in some cases to retrieve a formatted version of the `GenStateMachine`


### PR DESCRIPTION
While trying to compile an application against Elixir 1.8-dev:

```
➜  pretty_state_machine mix compile
==> gen_state_machine
Compiling 3 files (.ex)
warning: invalid type annotation. When using the | operator to represent the union of types, make sure to wrap type annotations in parentheses: {:ok, state, data} | {callback_mode, state, data} | reason :: term
  lib/gen_state_machine.ex:436


== Compilation error in file lib/gen_state_machine.ex ==
** (CompileError) lib/gen_state_machine.ex:436: type reason/0 undefined
    (elixir) lib/kernel/typespec.ex:815: Kernel.Typespec.compile_error/2
    (elixir) lib/kernel/typespec.ex:759: Kernel.Typespec.typespec/4
    (elixir) lib/enum.ex:1430: Enum."-map_reduce/3-lists^mapfoldl/2-0-"/3
    (elixir) lib/enum.ex:1430: Enum."-map_reduce/3-lists^mapfoldl/2-0-"/3
    (elixir) lib/kernel/typespec.ex:399: Kernel.Typespec.typespec/4
    (elixir) lib/kernel/typespec.ex:613: Kernel.Typespec.typespec/4
    (elixir) lib/kernel/typespec.ex:834: Kernel.Typespec.fn_args/6
    (elixir) lib/kernel/typespec.ex:333: Kernel.Typespec.translate_spec/8
could not compile dependency :gen_state_machine, "mix compile" failed. You can recompile this dependency with "mix deps.compile gen_state_machine", update it with "mix deps.update gen_state_machine" or clean it with "mix deps.clean gen_state_machine"
```