### PR TITLE
match stdlib version with 3+ symbols in version numbers

### DIFF
--- a/lib/gen_state_machine.ex
+++ b/lib/gen_state_machine.ex
@@ -473,7 +473,7 @@ defmodule GenStateMachine do
                                      |> (case do
                                            [major] -> "#{major}.0.0"
                                            [major, minor] -> "#{major}.#{minor}.0"
-                                           [major, minor, patch] -> "#{major}.#{minor}.#{patch}"
+                                           [major, minor, patch | _] -> "#{major}.#{minor}.#{patch}"
                                          end)
                                      |> Version.parse()
                                      |> elem(1)


### PR DESCRIPTION
Hi!
I have trouble with Travis CI build because of version matching.
[Erlang OTP 20.3.8.12](http://erlang.org/pipermail/erlang-questions/2018-November/096616.html) contains `stdlib-3.4.5.1` package with version, that cannot be parsed by `gen_state_machine` and build fails.
This PR fixes problem with matching stdlib version