### PR TITLE
Expose `event_handler_result` and `on_start` types

### DIFF
--- a/lib/gen_state_machine.ex
+++ b/lib/gen_state_machine.ex
@@ -306,6 +306,14 @@ defmodule GenStateMachine do
   """
   @type event_handler_result(state) :: :gen_statem.event_handler_result(state)
 
+  @typedoc """
+  The return type when the server is started.
+
+  See the erlang [documentation](https://erlang.org/documentation/doc-9.0/lib/stdlib-3.4/doc/html/gen_statem.html#type-start_ret)
+  for a complete reference.
+  """
+  @type on_start :: :gen_statem.start_ret()
+
   @doc """
   Invoked when the server is started. `start_link/3` (or `start/3`) will
   block until it returns.
@@ -654,7 +662,7 @@ defmodule GenStateMachine do
   or `:ignore`, the process is terminated and this function returns
   `{:error, reason}` or `:ignore`, respectively.
   """
-  @spec start_link(module, any, GenServer.options()) :: :gen_statem.start_ret()
+  @spec start_link(module, any, GenServer.options()) :: on_start()
   def start_link(module, args, options \\ []) do
     {name, options} = Keyword.pop(options, :name)
 
@@ -678,7 +686,7 @@ defmodule GenStateMachine do
 
   See `start_link/3` for more information.
   """
-  @spec start(module, any, GenServer.options()) :: :gen_statem.start_ret()
+  @spec start(module, any, GenServer.options()) :: on_start()
   def start(module, args, options \\ []) do
     {name, options} = Keyword.pop(options, :name)
 

--- a/lib/gen_state_machine.ex
+++ b/lib/gen_state_machine.ex
@@ -298,6 +298,14 @@ defmodule GenStateMachine do
   """
   @type action :: :gen_statem.action()
 
+  @typedoc """
+  The return type of an event handler function.
+
+  See the erlang [documentation](http://erlang.org/documentation/doc-9.0/lib/stdlib-3.4/doc/html/gen_statem.html#type-event_handler_result)
+  for a complete reference.
+  """
+  @type event_handler_result(state) :: :gen_statem.event_handler_result(state)
+
   @doc """
   Invoked when the server is started. `start_link/3` (or `start/3`) will
   block until it returns.
@@ -347,8 +355,7 @@ defmodule GenStateMachine do
   See the erlang [documentation](http://erlang.org/documentation/doc-9.0/lib/stdlib-3.4/doc/html/gen_statem.html#type-event_handler_result)
   for a complete reference.
   """
-  @callback state_name(event_type, event_content, data) ::
-              :gen_statem.event_handler_result(state_name())
+  @callback state_name(event_type, event_content, data) :: event_handler_result(state_name())
 
   @doc """
   Whenever a `GenStateMachine` in callback mode `:handle_event_function` (the
@@ -360,8 +367,7 @@ defmodule GenStateMachine do
   See the erlang [documentation](http://erlang.org/documentation/doc-9.0/lib/stdlib-3.4/doc/html/gen_statem.html#type-event_handler_result)
   for a complete reference.
   """
-  @callback handle_event(event_type, event_content, state, data) ::
-              :gen_statem.event_handler_result(state())
+  @callback handle_event(event_type, event_content, state, data) :: event_handler_result(state())
 
   @doc """
   Invoked when the server is about to exit. It should do any cleanup required.

--- a/mix.lock
+++ b/mix.lock
@@ -1,7 +1,8 @@
 %{
-  "earmark": {:hex, :earmark, "1.4.3", "364ca2e9710f6bff494117dbbd53880d84bebb692dafc3a78eb50aa3183f2bfd", [:mix], [], "hexpm"},
-  "ex_doc": {:hex, :ex_doc, "0.21.2", "caca5bc28ed7b3bdc0b662f8afe2bee1eedb5c3cf7b322feeeb7c6ebbde089d6", [:mix], [{:earmark, "~> 1.3.3 or ~> 1.4", [hex: :earmark, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.14", [hex: :makeup_elixir, repo: "hexpm", optional: false]}], "hexpm"},
-  "makeup": {:hex, :makeup, "1.0.0", "671df94cf5a594b739ce03b0d0316aa64312cee2574b6a44becb83cd90fb05dc", [:mix], [{:nimble_parsec, "~> 0.5.0", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm"},
-  "makeup_elixir": {:hex, :makeup_elixir, "0.14.0", "cf8b7c66ad1cff4c14679698d532f0b5d45a3968ffbcbfd590339cb57742f1ae", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm"},
-  "nimble_parsec": {:hex, :nimble_parsec, "0.5.3", "def21c10a9ed70ce22754fdeea0810dafd53c2db3219a0cd54cf5526377af1c6", [:mix], [], "hexpm"},
+  "earmark": {:hex, :earmark, "1.4.3", "364ca2e9710f6bff494117dbbd53880d84bebb692dafc3a78eb50aa3183f2bfd", [:mix], [], "hexpm", "8cf8a291ebf1c7b9539e3cddb19e9cef066c2441b1640f13c34c1d3cfc825fec"},
+  "earmark_parser": {:hex, :earmark_parser, "1.4.10", "6603d7a603b9c18d3d20db69921527f82ef09990885ed7525003c7fe7dc86c56", [:mix], [], "hexpm", "8e2d5370b732385db2c9b22215c3f59c84ac7dda7ed7e544d7c459496ae519c0"},
+  "ex_doc": {:hex, :ex_doc, "0.23.0", "a069bc9b0bf8efe323ecde8c0d62afc13d308b1fa3d228b65bca5cf8703a529d", [:mix], [{:earmark_parser, "~> 1.4.0", [hex: :earmark_parser, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.14", [hex: :makeup_elixir, repo: "hexpm", optional: false]}], "hexpm", "f5e2c4702468b2fd11b10d39416ddadd2fcdd173ba2a0285ebd92c39827a5a16"},
+  "makeup": {:hex, :makeup, "1.0.5", "d5a830bc42c9800ce07dd97fa94669dfb93d3bf5fcf6ea7a0c67b2e0e4a7f26c", [:mix], [{:nimble_parsec, "~> 0.5 or ~> 1.0", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm", "cfa158c02d3f5c0c665d0af11512fed3fba0144cf1aadee0f2ce17747fba2ca9"},
+  "makeup_elixir": {:hex, :makeup_elixir, "0.15.0", "98312c9f0d3730fde4049985a1105da5155bfe5c11e47bdc7406d88e01e4219b", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}, {:nimble_parsec, "~> 1.1", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm", "75ffa34ab1056b7e24844c90bfc62aaf6f3a37a15faa76b07bc5eba27e4a8b4a"},
+  "nimble_parsec": {:hex, :nimble_parsec, "1.1.0", "3a6fca1550363552e54c216debb6a9e95bd8d32348938e13de5eda962c0d7f89", [:mix], [], "hexpm", "08eb32d66b706e913ff748f11694b17981c0b04a33ef470e33e11b3d3ac8f54b"},
 }


### PR DESCRIPTION
This PR exposes the `:gen_statem.event_handler_result` type as adds an `on_start` type that delegates to `:gen_statem.start_ret()`. Both were necessary for me to correctly spec my `start_link` function and my state functions when using `GenStateMachine`.

I opted to use `on_start` rather than `start_ret` for consistency with `GenServer`. Please let me know if you'd rather I stick with the `start_ret` naming.