### PR TITLE
README, removed applications section

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,19 +24,11 @@ added to `Logger`.
 
 ## Installation
 
-  1. Add `gen_state_machine` to your list of dependencies in `mix.exs`:
+  Add `gen_state_machine` to your list of dependencies in `mix.exs`:
 
   ```elixir
   def deps do
     [{:gen_state_machine, "~> 3.0"}]
-  end
-  ```
-
-  2. Ensure `gen_state_machine` is added to your applications:
-
-  ```elixir
-  def application do
-    [applications: [:gen_state_machine]]
   end
   ```
 


### PR DESCRIPTION
Maybe modify the application section is not necessary.

I tried this package on elixir 1.14.0 without modify the application section and it works.

I followed this tutorial

https://dockyard.com/blog/2020/01/31/state-timeouts-with-gen_statem

More details:

https://www.amberbit.com/blog/2017/9/22/elixir-applications-vs-extra_applications-guide/