### PR TITLE
Update Erlang strings to use ~c sigil

### DIFF
--- a/lib/gen_state_machine/translator.ex
+++ b/lib/gen_state_machine/translator.ex
@@ -18,10 +18,10 @@ defmodule GenStateMachine.Translator do
     opts = Application.get_env(:logger, :translator_inspect_opts)
 
     case message do
-      {'** State machine ~tp terminating~n' ++ _ = format, args} ->
+      {~c"** State machine ~tp terminating~n" ++ _ = format, args} ->
         do_translate(min_level, format, args, opts)
 
-      {'** State machine ~p terminating~n' ++ _ = format, args} ->
+      {~c"** State machine ~p terminating~n" ++ _ = format, args} ->
         do_translate(min_level, format, args, opts)
 
       _ ->


### PR DESCRIPTION
This fixes the following warnings in Elixir 1.17:

```
==> gen_state_machine
Compiling 3 files (.ex)
    warning: single-quoted strings represent charlists. Use ~c"" if you indeed want a charlist or use "" instead
    │
 21 │       {'** State machine ~tp terminating~n' ++ _ = format, args} ->
    │        ~
    │
    └─ lib/gen_state_machine/translator.ex:21:8

    warning: single-quoted strings represent charlists. Use ~c"" if you indeed want a charlist or use "" instead
    │
 24 │       {'** State machine ~p terminating~n' ++ _ = format, args} ->
    │        ~
    │
    └─ lib/gen_state_machine/translator.ex:24:8
```
