### PR TITLE
fix: remove compiler deprecation warning re: `List.zip/1`

### DIFF
--- a/lib/gen_state_machine/translator.ex
+++ b/lib/gen_state_machine/translator.ex
@@ -59,7 +59,7 @@ defmodule GenStateMachine.Translator do
 
     args =
       [keys, args]
-      |> List.zip()
+      |> Enum.zip()
       |> Map.new()
 
     msg = [


### PR DESCRIPTION
Using Elixir v1.18.4

```console
$ mix deps.compile gen_state_machine
==> gen_state_machine
Compiling 3 files (.ex)
    ...

    warning: List.zip/1 is deprecated. Use Enum.zip/1 instead
    │
 62 │       |> List.zip()
    │               ~
    │
    └─ lib/gen_state_machine/translator.ex:62:15: GenStateMachine.Translator.do_translate/4
...
```